### PR TITLE
Rename InsurancePal -> ClientBook (the storage, not the app)

### DIFF
--- a/src/main/java/seedu/insurancepal/MainApp.java
+++ b/src/main/java/seedu/insurancepal/MainApp.java
@@ -15,10 +15,10 @@ import seedu.insurancepal.commons.util.ConfigUtil;
 import seedu.insurancepal.commons.util.StringUtil;
 import seedu.insurancepal.logic.Logic;
 import seedu.insurancepal.logic.LogicManager;
-import seedu.insurancepal.model.InsurancePal;
+import seedu.insurancepal.model.ClientBook;
 import seedu.insurancepal.model.Model;
 import seedu.insurancepal.model.ModelManager;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 import seedu.insurancepal.model.ReadOnlyUserPrefs;
 import seedu.insurancepal.model.UserPrefs;
 import seedu.insurancepal.model.util.SampleDataUtil;
@@ -74,20 +74,20 @@ public class MainApp extends Application {
      * or an empty address book will be used instead if errors occur when reading {@code storage}'s address book.
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
-        Optional<ReadOnlyInsurancePal> addressBookOptional;
-        ReadOnlyInsurancePal initialData;
+        Optional<ReadOnlyClientBook> addressBookOptional;
+        ReadOnlyClientBook initialData;
         try {
-            addressBookOptional = storage.readInsurancePal();
+            addressBookOptional = storage.readClientBook();
             if (!addressBookOptional.isPresent()) {
                 logger.info("Data file not found. Will be starting with a sample InsurancePal");
             }
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataConversionException e) {
             logger.warning("Data file not in the correct format. Will be starting with an empty InsurancePal");
-            initialData = new InsurancePal();
+            initialData = new ClientBook();
         } catch (IOException e) {
             logger.warning("Problem while reading from the file. Will be starting with an empty InsurancePal");
-            initialData = new InsurancePal();
+            initialData = new ClientBook();
         }
 
         return new ModelManager(initialData, userPrefs);

--- a/src/main/java/seedu/insurancepal/logic/Logic.java
+++ b/src/main/java/seedu/insurancepal/logic/Logic.java
@@ -7,7 +7,7 @@ import seedu.insurancepal.commons.core.GuiSettings;
 import seedu.insurancepal.logic.commands.CommandResult;
 import seedu.insurancepal.logic.commands.exceptions.CommandException;
 import seedu.insurancepal.logic.parser.exceptions.ParseException;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 import seedu.insurancepal.model.person.Person;
 
 /**
@@ -28,7 +28,7 @@ public interface Logic {
      *
      * @see seedu.insurancepal.model.Model#getAddressBook()
      */
-    ReadOnlyInsurancePal getAddressBook();
+    ReadOnlyClientBook getClientBook();
 
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
@@ -42,7 +42,7 @@ public interface Logic {
     /**
      * Returns the user prefs' address book file path.
      */
-    Path getAddressBookFilePath();
+    Path getClientBookFilePath();
 
     /**
      * Returns the user prefs' GUI settings.

--- a/src/main/java/seedu/insurancepal/logic/LogicManager.java
+++ b/src/main/java/seedu/insurancepal/logic/LogicManager.java
@@ -13,7 +13,7 @@ import seedu.insurancepal.logic.commands.exceptions.CommandException;
 import seedu.insurancepal.logic.parser.InsurancePalParser;
 import seedu.insurancepal.logic.parser.exceptions.ParseException;
 import seedu.insurancepal.model.Model;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 import seedu.insurancepal.model.person.Person;
 import seedu.insurancepal.storage.Storage;
 
@@ -55,7 +55,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ReadOnlyInsurancePal getAddressBook() {
+    public ReadOnlyClientBook getClientBook() {
         return model.getAddressBook();
     }
 
@@ -74,7 +74,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public Path getAddressBookFilePath() {
+    public Path getClientBookFilePath() {
         return model.getAddressBookFilePath();
     }
 

--- a/src/main/java/seedu/insurancepal/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/insurancepal/logic/commands/ClearCommand.java
@@ -2,7 +2,7 @@ package seedu.insurancepal.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import seedu.insurancepal.model.InsurancePal;
+import seedu.insurancepal.model.ClientBook;
 import seedu.insurancepal.model.Model;
 
 /**
@@ -17,7 +17,7 @@ public class ClearCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setAddressBook(new InsurancePal());
+        model.setAddressBook(new ClientBook());
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/insurancepal/model/ClientBook.java
+++ b/src/main/java/seedu/insurancepal/model/ClientBook.java
@@ -12,7 +12,7 @@ import seedu.insurancepal.model.person.UniquePersonList;
  * Wraps all data at the address-book level
  * Duplicates are not allowed (by .isSamePerson comparison)
  */
-public class InsurancePal implements ReadOnlyInsurancePal {
+public class ClientBook implements ReadOnlyClientBook {
 
     private final UniquePersonList persons;
 
@@ -27,12 +27,12 @@ public class InsurancePal implements ReadOnlyInsurancePal {
         persons = new UniquePersonList();
     }
 
-    public InsurancePal() {}
+    public ClientBook() {}
 
     /**
      * Creates an InsurancePal using the Persons in the {@code toBeCopied}
      */
-    public InsurancePal(ReadOnlyInsurancePal toBeCopied) {
+    public ClientBook(ReadOnlyClientBook toBeCopied) {
         this();
         resetData(toBeCopied);
     }
@@ -50,7 +50,7 @@ public class InsurancePal implements ReadOnlyInsurancePal {
     /**
      * Resets the existing data of this {@code InsurancePal} with {@code newData}.
      */
-    public void resetData(ReadOnlyInsurancePal newData) {
+    public void resetData(ReadOnlyClientBook newData) {
         requireNonNull(newData);
 
         setPersons(newData.getPersonList());
@@ -109,8 +109,8 @@ public class InsurancePal implements ReadOnlyInsurancePal {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof InsurancePal // instanceof handles nulls
-                && persons.equals(((InsurancePal) other).persons));
+                || (other instanceof ClientBook // instanceof handles nulls
+                && persons.equals(((ClientBook) other).persons));
     }
 
     @Override

--- a/src/main/java/seedu/insurancepal/model/Model.java
+++ b/src/main/java/seedu/insurancepal/model/Model.java
@@ -47,10 +47,10 @@ public interface Model {
     /**
      * Replaces address book data with the data in {@code addressBook}.
      */
-    void setAddressBook(ReadOnlyInsurancePal addressBook);
+    void setAddressBook(ReadOnlyClientBook addressBook);
 
     /** Returns the InsurancePal */
-    ReadOnlyInsurancePal getAddressBook();
+    ReadOnlyClientBook getAddressBook();
 
     /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.

--- a/src/main/java/seedu/insurancepal/model/ModelManager.java
+++ b/src/main/java/seedu/insurancepal/model/ModelManager.java
@@ -20,26 +20,26 @@ import seedu.insurancepal.model.person.Person;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final InsurancePal addressBook;
+    private final ClientBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
-    public ModelManager(ReadOnlyInsurancePal addressBook, ReadOnlyUserPrefs userPrefs) {
+    public ModelManager(ReadOnlyClientBook addressBook, ReadOnlyUserPrefs userPrefs) {
         super();
         requireAllNonNull(addressBook, userPrefs);
 
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
-        this.addressBook = new InsurancePal(addressBook);
+        this.addressBook = new ClientBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
     }
 
     public ModelManager() {
-        this(new InsurancePal(), new UserPrefs());
+        this(new ClientBook(), new UserPrefs());
     }
 
     //=========== UserPrefs ==================================================================================
@@ -80,12 +80,12 @@ public class ModelManager implements Model {
     //=========== InsurancePal ================================================================================
 
     @Override
-    public void setAddressBook(ReadOnlyInsurancePal addressBook) {
+    public void setAddressBook(ReadOnlyClientBook addressBook) {
         this.addressBook.resetData(addressBook);
     }
 
     @Override
-    public ReadOnlyInsurancePal getAddressBook() {
+    public ReadOnlyClientBook getAddressBook() {
         return addressBook;
     }
 

--- a/src/main/java/seedu/insurancepal/model/ReadOnlyClientBook.java
+++ b/src/main/java/seedu/insurancepal/model/ReadOnlyClientBook.java
@@ -6,7 +6,7 @@ import seedu.insurancepal.model.person.Person;
 /**
  * Unmodifiable view of an address book
  */
-public interface ReadOnlyInsurancePal {
+public interface ReadOnlyClientBook {
 
     /**
      * Returns an unmodifiable view of the persons list.

--- a/src/main/java/seedu/insurancepal/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/insurancepal/model/util/SampleDataUtil.java
@@ -6,8 +6,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.insurancepal.commons.core.Money;
-import seedu.insurancepal.model.InsurancePal;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ClientBook;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 import seedu.insurancepal.model.appointment.Appointment;
 import seedu.insurancepal.model.claim.Claim;
 import seedu.insurancepal.model.claim.Description;
@@ -67,8 +67,8 @@ public class SampleDataUtil {
         };
     }
 
-    public static ReadOnlyInsurancePal getSampleAddressBook() {
-        InsurancePal sampleAb = new InsurancePal();
+    public static ReadOnlyClientBook getSampleAddressBook() {
+        ClientBook sampleAb = new ClientBook();
         for (Person samplePerson : getSamplePersons()) {
             sampleAb.addPerson(samplePerson);
         }

--- a/src/main/java/seedu/insurancepal/storage/InsurancePalStorage.java
+++ b/src/main/java/seedu/insurancepal/storage/InsurancePalStorage.java
@@ -5,11 +5,11 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.insurancepal.commons.exceptions.DataConversionException;
-import seedu.insurancepal.model.InsurancePal;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ClientBook;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 
 /**
- * Represents a storage for {@link InsurancePal}.
+ * Represents a storage for {@link ClientBook}.
  */
 public interface InsurancePalStorage {
 
@@ -19,28 +19,28 @@ public interface InsurancePalStorage {
     Path getInsurancePalFilePath();
 
     /**
-     * Returns InsurancePal data as a {@link ReadOnlyInsurancePal}.
+     * Returns InsurancePal data as a {@link ReadOnlyClientBook}.
      *   Returns {@code Optional.empty()} if storage file is not found.
      * @throws DataConversionException if the data in storage is not in the expected format.
      * @throws IOException if there was any problem when reading from the storage.
      */
-    Optional<ReadOnlyInsurancePal> readInsurancePal() throws DataConversionException, IOException;
+    Optional<ReadOnlyClientBook> readClientBook() throws DataConversionException, IOException;
 
     /**
      * @see #getInsurancePalFilePath()
      */
-    Optional<ReadOnlyInsurancePal> readInsurancePal(Path filePath) throws DataConversionException, IOException;
+    Optional<ReadOnlyClientBook> readClientBook(Path filePath) throws DataConversionException, IOException;
 
     /**
-     * Saves the given {@link ReadOnlyInsurancePal} to the storage.
+     * Saves the given {@link ReadOnlyClientBook} to the storage.
      * @param insurancePal cannot be null.
      * @throws IOException if there was any problem writing to the file.
      */
-    void saveInsurancePal(ReadOnlyInsurancePal insurancePal) throws IOException;
+    void saveInsurancePal(ReadOnlyClientBook insurancePal) throws IOException;
 
     /**
-     * @see #saveInsurancePal(ReadOnlyInsurancePal)
+     * @see #saveInsurancePal(ReadOnlyClientBook)
      */
-    void saveInsurancePal(ReadOnlyInsurancePal insurancePal, Path filePath) throws IOException;
+    void saveInsurancePal(ReadOnlyClientBook insurancePal, Path filePath) throws IOException;
 
 }

--- a/src/main/java/seedu/insurancepal/storage/JsonInsurancePalStorage.java
+++ b/src/main/java/seedu/insurancepal/storage/JsonInsurancePalStorage.java
@@ -12,7 +12,7 @@ import seedu.insurancepal.commons.exceptions.DataConversionException;
 import seedu.insurancepal.commons.exceptions.IllegalValueException;
 import seedu.insurancepal.commons.util.FileUtil;
 import seedu.insurancepal.commons.util.JsonUtil;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 
 /**
  * A class to access InsurancePal data stored as a json file on the hard disk.
@@ -32,21 +32,21 @@ public class JsonInsurancePalStorage implements InsurancePalStorage {
     }
 
     @Override
-    public Optional<ReadOnlyInsurancePal> readInsurancePal() throws DataConversionException {
-        return readInsurancePal(filePath);
+    public Optional<ReadOnlyClientBook> readClientBook() throws DataConversionException {
+        return readClientBook(filePath);
     }
 
     /**
-     * Similar to {@link #readInsurancePal()}.
+     * Similar to {@link #readClientBook()}.
      *
      * @param filePath location of the data. Cannot be null.
      * @throws DataConversionException if the file is not in the correct format.
      */
-    public Optional<ReadOnlyInsurancePal> readInsurancePal(Path filePath) throws DataConversionException {
+    public Optional<ReadOnlyClientBook> readClientBook(Path filePath) throws DataConversionException {
         requireNonNull(filePath);
 
-        Optional<JsonSerializableInsurancePal> jsonAddressBook = JsonUtil.readJsonFile(
-                filePath, JsonSerializableInsurancePal.class);
+        Optional<JsonSerializableClientBook> jsonAddressBook = JsonUtil.readJsonFile(
+                filePath, JsonSerializableClientBook.class);
         if (!jsonAddressBook.isPresent()) {
             return Optional.empty();
         }
@@ -60,21 +60,21 @@ public class JsonInsurancePalStorage implements InsurancePalStorage {
     }
 
     @Override
-    public void saveInsurancePal(ReadOnlyInsurancePal addressBook) throws IOException {
+    public void saveInsurancePal(ReadOnlyClientBook addressBook) throws IOException {
         saveInsurancePal(addressBook, filePath);
     }
 
     /**
-     * Similar to {@link #saveInsurancePal(ReadOnlyInsurancePal)}.
+     * Similar to {@link #saveInsurancePal(ReadOnlyClientBook)}.
      *
      * @param filePath location of the data. Cannot be null.
      */
-    public void saveInsurancePal(ReadOnlyInsurancePal addressBook, Path filePath) throws IOException {
+    public void saveInsurancePal(ReadOnlyClientBook addressBook, Path filePath) throws IOException {
         requireNonNull(addressBook);
         requireNonNull(filePath);
 
         FileUtil.createIfMissing(filePath);
-        JsonUtil.saveJsonFile(new JsonSerializableInsurancePal(addressBook), filePath);
+        JsonUtil.saveJsonFile(new JsonSerializableClientBook(addressBook), filePath);
     }
 
 }

--- a/src/main/java/seedu/insurancepal/storage/JsonSerializableClientBook.java
+++ b/src/main/java/seedu/insurancepal/storage/JsonSerializableClientBook.java
@@ -9,15 +9,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 import seedu.insurancepal.commons.exceptions.IllegalValueException;
-import seedu.insurancepal.model.InsurancePal;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ClientBook;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 import seedu.insurancepal.model.person.Person;
 
 /**
  * An Immutable InsurancePal that is serializable to JSON format.
  */
 @JsonRootName(value = "addressbook")
-class JsonSerializableInsurancePal {
+class JsonSerializableClientBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
 
@@ -27,7 +27,7 @@ class JsonSerializableInsurancePal {
      * Constructs a {@code JsonSerializableInsurancePal} with the given persons.
      */
     @JsonCreator
-    public JsonSerializableInsurancePal(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
+    public JsonSerializableClientBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
         this.persons.addAll(persons);
     }
 
@@ -36,7 +36,7 @@ class JsonSerializableInsurancePal {
      *
      * @param source future changes to this will not affect the created {@code JsonSerializableInsurancePal}.
      */
-    public JsonSerializableInsurancePal(ReadOnlyInsurancePal source) {
+    public JsonSerializableClientBook(ReadOnlyClientBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
     }
 
@@ -45,16 +45,16 @@ class JsonSerializableInsurancePal {
      *
      * @throws IllegalValueException if there were any data constraints violated.
      */
-    public InsurancePal toModelType() throws IllegalValueException {
-        InsurancePal insurancePal = new InsurancePal();
+    public ClientBook toModelType() throws IllegalValueException {
+        ClientBook clientBook = new ClientBook();
         for (JsonAdaptedPerson jsonAdaptedPerson : persons) {
             Person person = jsonAdaptedPerson.toModelType();
-            if (insurancePal.hasPerson(person)) {
+            if (clientBook.hasPerson(person)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
-            insurancePal.addPerson(person);
+            clientBook.addPerson(person);
         }
-        return insurancePal;
+        return clientBook;
     }
 
 }

--- a/src/main/java/seedu/insurancepal/storage/Storage.java
+++ b/src/main/java/seedu/insurancepal/storage/Storage.java
@@ -5,7 +5,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.insurancepal.commons.exceptions.DataConversionException;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 import seedu.insurancepal.model.ReadOnlyUserPrefs;
 import seedu.insurancepal.model.UserPrefs;
 
@@ -24,9 +24,9 @@ public interface Storage extends InsurancePalStorage, UserPrefsStorage {
     Path getInsurancePalFilePath();
 
     @Override
-    Optional<ReadOnlyInsurancePal> readInsurancePal() throws DataConversionException, IOException;
+    Optional<ReadOnlyClientBook> readClientBook() throws DataConversionException, IOException;
 
     @Override
-    void saveInsurancePal(ReadOnlyInsurancePal addressBook) throws IOException;
+    void saveInsurancePal(ReadOnlyClientBook addressBook) throws IOException;
 
 }

--- a/src/main/java/seedu/insurancepal/storage/StorageManager.java
+++ b/src/main/java/seedu/insurancepal/storage/StorageManager.java
@@ -7,7 +7,7 @@ import java.util.logging.Logger;
 
 import seedu.insurancepal.commons.core.LogsCenter;
 import seedu.insurancepal.commons.exceptions.DataConversionException;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 import seedu.insurancepal.model.ReadOnlyUserPrefs;
 import seedu.insurancepal.model.UserPrefs;
 
@@ -55,23 +55,23 @@ public class StorageManager implements Storage {
     }
 
     @Override
-    public Optional<ReadOnlyInsurancePal> readInsurancePal() throws DataConversionException, IOException {
-        return readInsurancePal(insurancePalStorage.getInsurancePalFilePath());
+    public Optional<ReadOnlyClientBook> readClientBook() throws DataConversionException, IOException {
+        return readClientBook(insurancePalStorage.getInsurancePalFilePath());
     }
 
     @Override
-    public Optional<ReadOnlyInsurancePal> readInsurancePal(Path filePath) throws DataConversionException, IOException {
+    public Optional<ReadOnlyClientBook> readClientBook(Path filePath) throws DataConversionException, IOException {
         logger.fine("Attempting to read data from file: " + filePath);
-        return insurancePalStorage.readInsurancePal(filePath);
+        return insurancePalStorage.readClientBook(filePath);
     }
 
     @Override
-    public void saveInsurancePal(ReadOnlyInsurancePal addressBook) throws IOException {
+    public void saveInsurancePal(ReadOnlyClientBook addressBook) throws IOException {
         saveInsurancePal(addressBook, insurancePalStorage.getInsurancePalFilePath());
     }
 
     @Override
-    public void saveInsurancePal(ReadOnlyInsurancePal addressBook, Path filePath) throws IOException {
+    public void saveInsurancePal(ReadOnlyClientBook addressBook, Path filePath) throws IOException {
         logger.fine("Attempting to write to data file: " + filePath);
         insurancePalStorage.saveInsurancePal(addressBook, filePath);
     }

--- a/src/main/java/seedu/insurancepal/ui/MainWindow.java
+++ b/src/main/java/seedu/insurancepal/ui/MainWindow.java
@@ -131,7 +131,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
+        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getClientBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand);

--- a/src/test/java/seedu/insurancepal/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/insurancepal/logic/LogicManagerTest.java
@@ -24,7 +24,7 @@ import seedu.insurancepal.logic.commands.exceptions.CommandException;
 import seedu.insurancepal.logic.parser.exceptions.ParseException;
 import seedu.insurancepal.model.Model;
 import seedu.insurancepal.model.ModelManager;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 import seedu.insurancepal.model.UserPrefs;
 import seedu.insurancepal.model.person.Person;
 import seedu.insurancepal.storage.JsonInsurancePalStorage;
@@ -43,10 +43,10 @@ public class LogicManagerTest {
 
     @BeforeEach
     public void setUp() {
-        JsonInsurancePalStorage addressBookStorage =
+        JsonInsurancePalStorage insurancePalStorageStorage =
                 new JsonInsurancePalStorage(temporaryFolder.resolve("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        StorageManager storage = new StorageManager(insurancePalStorageStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);
     }
 
@@ -160,7 +160,7 @@ public class LogicManagerTest {
         }
 
         @Override
-        public void saveInsurancePal(ReadOnlyInsurancePal addressBook, Path filePath) throws IOException {
+        public void saveInsurancePal(ReadOnlyClientBook addressBook, Path filePath) throws IOException {
             throw DUMMY_IO_EXCEPTION;
         }
     }

--- a/src/test/java/seedu/insurancepal/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/insurancepal/logic/commands/AddCommandTest.java
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.ObservableList;
 import seedu.insurancepal.commons.core.GuiSettings;
 import seedu.insurancepal.logic.commands.exceptions.CommandException;
-import seedu.insurancepal.model.InsurancePal;
+import seedu.insurancepal.model.ClientBook;
 import seedu.insurancepal.model.Model;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 import seedu.insurancepal.model.ReadOnlyUserPrefs;
 import seedu.insurancepal.model.person.Person;
 import seedu.insurancepal.testutil.PersonBuilder;
@@ -114,12 +114,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public void setAddressBook(ReadOnlyInsurancePal newData) {
+        public void setAddressBook(ReadOnlyClientBook newData) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public ReadOnlyInsurancePal getAddressBook() {
+        public ReadOnlyClientBook getAddressBook() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -196,8 +196,8 @@ public class AddCommandTest {
         }
 
         @Override
-        public ReadOnlyInsurancePal getAddressBook() {
-            return new InsurancePal();
+        public ReadOnlyClientBook getAddressBook() {
+            return new ClientBook();
         }
     }
 

--- a/src/test/java/seedu/insurancepal/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/insurancepal/logic/commands/ClearCommandTest.java
@@ -5,7 +5,7 @@ import static seedu.insurancepal.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.insurancepal.model.InsurancePal;
+import seedu.insurancepal.model.ClientBook;
 import seedu.insurancepal.model.Model;
 import seedu.insurancepal.model.ModelManager;
 import seedu.insurancepal.model.UserPrefs;
@@ -24,7 +24,7 @@ public class ClearCommandTest {
     public void execute_nonEmptyAddressBook_success() {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel.setAddressBook(new InsurancePal());
+        expectedModel.setAddressBook(new ClientBook());
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/seedu/insurancepal/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/insurancepal/logic/commands/CommandTestUtil.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import seedu.insurancepal.commons.core.index.Index;
 import seedu.insurancepal.logic.commands.exceptions.CommandException;
-import seedu.insurancepal.model.InsurancePal;
+import seedu.insurancepal.model.ClientBook;
 import seedu.insurancepal.model.Model;
 import seedu.insurancepal.model.claim.Claim;
 import seedu.insurancepal.model.claim.Description;
@@ -150,7 +150,7 @@ public class CommandTestUtil {
     public static void assertCommandFailure(Command command, Model actualModel, String expectedMessage) {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
-        InsurancePal expectedAddressBook = new InsurancePal(actualModel.getAddressBook());
+        ClientBook expectedAddressBook = new ClientBook(actualModel.getAddressBook());
         List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
 
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));

--- a/src/test/java/seedu/insurancepal/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/insurancepal/logic/commands/EditCommandTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import seedu.insurancepal.commons.core.Messages;
 import seedu.insurancepal.commons.core.index.Index;
 import seedu.insurancepal.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.insurancepal.model.InsurancePal;
+import seedu.insurancepal.model.ClientBook;
 import seedu.insurancepal.model.Model;
 import seedu.insurancepal.model.ModelManager;
 import seedu.insurancepal.model.UserPrefs;
@@ -43,7 +43,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new InsurancePal(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ClientBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -65,7 +65,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new InsurancePal(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ClientBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -78,7 +78,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new InsurancePal(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ClientBook(model.getAddressBook()), new UserPrefs());
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -94,7 +94,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new InsurancePal(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ClientBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/insurancepal/logic/commands/NoteCommandTest.java
+++ b/src/test/java/seedu/insurancepal/logic/commands/NoteCommandTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.insurancepal.commons.core.Messages;
 import seedu.insurancepal.commons.core.index.Index;
-import seedu.insurancepal.model.InsurancePal;
+import seedu.insurancepal.model.ClientBook;
 import seedu.insurancepal.model.Model;
 import seedu.insurancepal.model.ModelManager;
 import seedu.insurancepal.model.UserPrefs;
@@ -43,7 +43,7 @@ class NoteCommandTest {
 
         String expectedMessage = String.format(NoteCommand.MESSAGE_ADD_NOTE_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new InsurancePal(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ClientBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
 
         assertCommandSuccess(noteCommand, model, expectedMessage, expectedModel);
@@ -59,7 +59,7 @@ class NoteCommandTest {
 
         String expectedMessage = String.format(NoteCommand.MESSAGE_DELETE_NOTE_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new InsurancePal(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ClientBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
 
         assertCommandSuccess(noteCommand, model, expectedMessage, expectedModel);
@@ -77,7 +77,7 @@ class NoteCommandTest {
 
         String expectedMessage = String.format(NoteCommand.MESSAGE_ADD_NOTE_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new InsurancePal(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ClientBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
 
         assertCommandSuccess(noteCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/insurancepal/logic/commands/RevenueCommandTest.java
+++ b/src/test/java/seedu/insurancepal/logic/commands/RevenueCommandTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import seedu.insurancepal.commons.core.Messages;
 import seedu.insurancepal.commons.core.Money;
 import seedu.insurancepal.commons.core.index.Index;
-import seedu.insurancepal.model.InsurancePal;
+import seedu.insurancepal.model.ClientBook;
 import seedu.insurancepal.model.Model;
 import seedu.insurancepal.model.ModelManager;
 import seedu.insurancepal.model.UserPrefs;
@@ -38,7 +38,7 @@ public class RevenueCommandTest {
 
         String expectedMessage = String.format(RevenueCommand.MESSAGE_ADD_REVENUE_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new InsurancePal(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ClientBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
 
         assertCommandSuccess(revenueCommand, model, expectedMessage, expectedModel);
@@ -57,7 +57,7 @@ public class RevenueCommandTest {
 
         String expectedMessage = String.format(RevenueCommand.MESSAGE_ADD_REVENUE_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new InsurancePal(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ClientBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
 
         assertCommandSuccess(revenueCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/insurancepal/logic/parser/ClientBookParserTest.java
+++ b/src/test/java/seedu/insurancepal/logic/parser/ClientBookParserTest.java
@@ -31,7 +31,7 @@ import seedu.insurancepal.testutil.EditPersonDescriptorBuilder;
 import seedu.insurancepal.testutil.PersonBuilder;
 import seedu.insurancepal.testutil.PersonUtil;
 
-public class InsurancePalParserTest {
+public class ClientBookParserTest {
 
     private final InsurancePalParser parser = new InsurancePalParser();
 

--- a/src/test/java/seedu/insurancepal/model/AddressBookTest.java
+++ b/src/test/java/seedu/insurancepal/model/AddressBookTest.java
@@ -24,7 +24,7 @@ import seedu.insurancepal.testutil.PersonBuilder;
 
 public class AddressBookTest {
 
-    private final InsurancePal addressBook = new InsurancePal();
+    private final ClientBook addressBook = new ClientBook();
 
     @Test
     public void constructor() {
@@ -38,7 +38,7 @@ public class AddressBookTest {
 
     @Test
     public void resetData_withValidReadOnlyAddressBook_replacesData() {
-        InsurancePal newData = getTypicalAddressBook();
+        ClientBook newData = getTypicalAddressBook();
         addressBook.resetData(newData);
         assertEquals(newData, addressBook);
     }
@@ -49,7 +49,7 @@ public class AddressBookTest {
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         List<Person> newPersons = Arrays.asList(ALICE, editedAlice);
-        InsurancePalStub newData = new InsurancePalStub(newPersons);
+        ClientBookStub newData = new ClientBookStub(newPersons);
 
         assertThrows(DuplicatePersonException.class, () -> addressBook.resetData(newData));
     }
@@ -86,10 +86,10 @@ public class AddressBookTest {
     /**
      * A stub ReadOnlyInsurancePal whose persons list can violate interface constraints.
      */
-    private static class InsurancePalStub implements ReadOnlyInsurancePal {
+    private static class ClientBookStub implements ReadOnlyClientBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
 
-        InsurancePalStub(Collection<Person> persons) {
+        ClientBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
         }
 

--- a/src/test/java/seedu/insurancepal/model/ModelManagerTest.java
+++ b/src/test/java/seedu/insurancepal/model/ModelManagerTest.java
@@ -26,7 +26,7 @@ public class ModelManagerTest {
     public void constructor() {
         assertEquals(new UserPrefs(), modelManager.getUserPrefs());
         assertEquals(new GuiSettings(), modelManager.getGuiSettings());
-        assertEquals(new InsurancePal(), new InsurancePal(modelManager.getAddressBook()));
+        assertEquals(new ClientBook(), new ClientBook(modelManager.getAddressBook()));
     }
 
     @Test
@@ -100,8 +100,8 @@ public class ModelManagerTest {
 
     @Test
     public void equals() {
-        InsurancePal addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
-        InsurancePal differentAddressBook = new InsurancePal();
+        ClientBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
+        ClientBook differentAddressBook = new ClientBook();
         UserPrefs userPrefs = new UserPrefs();
 
         // same values -> returns true

--- a/src/test/java/seedu/insurancepal/storage/JsonClientBookStorageTest.java
+++ b/src/test/java/seedu/insurancepal/storage/JsonClientBookStorageTest.java
@@ -16,10 +16,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import seedu.insurancepal.commons.exceptions.DataConversionException;
-import seedu.insurancepal.model.InsurancePal;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ClientBook;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 
-public class JsonInsurancePalStorageTest {
+public class JsonClientBookStorageTest {
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonInsurancePalStorageTest");
 
     @TempDir
@@ -30,8 +30,8 @@ public class JsonInsurancePalStorageTest {
         assertThrows(NullPointerException.class, () -> readAddressBook(null));
     }
 
-    private java.util.Optional<ReadOnlyInsurancePal> readAddressBook(String filePath) throws Exception {
-        return new JsonInsurancePalStorage(Paths.get(filePath)).readInsurancePal(addToTestDataPathIfNotNull(filePath));
+    private java.util.Optional<ReadOnlyClientBook> readAddressBook(String filePath) throws Exception {
+        return new JsonInsurancePalStorage(Paths.get(filePath)).readClientBook(addToTestDataPathIfNotNull(filePath));
     }
 
     private Path addToTestDataPathIfNotNull(String prefsFileInTestDataFolder) {
@@ -63,26 +63,26 @@ public class JsonInsurancePalStorageTest {
     @Test
     public void readAndSaveAddressBook_allInOrder_success() throws Exception {
         Path filePath = testFolder.resolve("TempAddressBook.json");
-        InsurancePal original = getTypicalAddressBook();
+        ClientBook original = getTypicalAddressBook();
         JsonInsurancePalStorage jsonAddressBookStorage = new JsonInsurancePalStorage(filePath);
 
         // Save in new file and read back
         jsonAddressBookStorage.saveInsurancePal(original, filePath);
-        ReadOnlyInsurancePal readBack = jsonAddressBookStorage.readInsurancePal(filePath).get();
-        assertEquals(original, new InsurancePal(readBack));
+        ReadOnlyClientBook readBack = jsonAddressBookStorage.readClientBook(filePath).get();
+        assertEquals(original, new ClientBook(readBack));
 
         // Modify data, overwrite exiting file, and read back
         original.addPerson(HOON);
         original.removePerson(ALICE);
         jsonAddressBookStorage.saveInsurancePal(original, filePath);
-        readBack = jsonAddressBookStorage.readInsurancePal(filePath).get();
-        assertEquals(original, new InsurancePal(readBack));
+        readBack = jsonAddressBookStorage.readClientBook(filePath).get();
+        assertEquals(original, new ClientBook(readBack));
 
         // Save and read without specifying file path
         original.addPerson(IDA);
         jsonAddressBookStorage.saveInsurancePal(original); // file path not specified
-        readBack = jsonAddressBookStorage.readInsurancePal().get(); // file path not specified
-        assertEquals(original, new InsurancePal(readBack));
+        readBack = jsonAddressBookStorage.readClientBook().get(); // file path not specified
+        assertEquals(original, new ClientBook(readBack));
 
     }
 
@@ -94,7 +94,7 @@ public class JsonInsurancePalStorageTest {
     /**
      * Saves {@code addressBook} at the specified {@code filePath}.
      */
-    private void saveAddressBook(ReadOnlyInsurancePal addressBook, String filePath) {
+    private void saveAddressBook(ReadOnlyClientBook addressBook, String filePath) {
         try {
             new JsonInsurancePalStorage(Paths.get(filePath))
                     .saveInsurancePal(addressBook, addToTestDataPathIfNotNull(filePath));
@@ -105,6 +105,6 @@ public class JsonInsurancePalStorageTest {
 
     @Test
     public void saveAddressBook_nullFilePath_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> saveAddressBook(new InsurancePal(), null));
+        assertThrows(NullPointerException.class, () -> saveAddressBook(new ClientBook(), null));
     }
 }

--- a/src/test/java/seedu/insurancepal/storage/JsonSerializableClientBookTest.java
+++ b/src/test/java/seedu/insurancepal/storage/JsonSerializableClientBookTest.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test;
 
 import seedu.insurancepal.commons.exceptions.IllegalValueException;
 import seedu.insurancepal.commons.util.JsonUtil;
-import seedu.insurancepal.model.InsurancePal;
+import seedu.insurancepal.model.ClientBook;
 import seedu.insurancepal.testutil.TypicalPersons;
 
-public class JsonSerializableInsurancePalTest {
+public class JsonSerializableClientBookTest {
 
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonSerializableInsurancePalTest");
     private static final Path TYPICAL_PERSONS_FILE = TEST_DATA_FOLDER.resolve("typicalPersonsAddressBook.json");
@@ -22,25 +22,25 @@ public class JsonSerializableInsurancePalTest {
 
     @Test
     public void toModelType_typicalPersonsFile_success() throws Exception {
-        JsonSerializableInsurancePal dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
-                JsonSerializableInsurancePal.class).get();
-        InsurancePal addressBookFromFile = dataFromFile.toModelType();
-        InsurancePal typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
+        JsonSerializableClientBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
+                JsonSerializableClientBook.class).get();
+        ClientBook addressBookFromFile = dataFromFile.toModelType();
+        ClientBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 
     @Test
     public void toModelType_invalidPersonFile_throwsIllegalValueException() throws Exception {
-        JsonSerializableInsurancePal dataFromFile = JsonUtil.readJsonFile(INVALID_PERSON_FILE,
-                JsonSerializableInsurancePal.class).get();
+        JsonSerializableClientBook dataFromFile = JsonUtil.readJsonFile(INVALID_PERSON_FILE,
+                JsonSerializableClientBook.class).get();
         assertThrows(IllegalValueException.class, dataFromFile::toModelType);
     }
 
     @Test
     public void toModelType_duplicatePersons_throwsIllegalValueException() throws Exception {
-        JsonSerializableInsurancePal dataFromFile = JsonUtil.readJsonFile(DUPLICATE_PERSON_FILE,
-                JsonSerializableInsurancePal.class).get();
-        assertThrows(IllegalValueException.class, JsonSerializableInsurancePal.MESSAGE_DUPLICATE_PERSON,
+        JsonSerializableClientBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_PERSON_FILE,
+                JsonSerializableClientBook.class).get();
+        assertThrows(IllegalValueException.class, JsonSerializableClientBook.MESSAGE_DUPLICATE_PERSON,
                 dataFromFile::toModelType);
     }
 

--- a/src/test/java/seedu/insurancepal/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/insurancepal/storage/StorageManagerTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import seedu.insurancepal.commons.core.GuiSettings;
-import seedu.insurancepal.model.InsurancePal;
-import seedu.insurancepal.model.ReadOnlyInsurancePal;
+import seedu.insurancepal.model.ClientBook;
+import seedu.insurancepal.model.ReadOnlyClientBook;
 import seedu.insurancepal.model.UserPrefs;
 
 public class StorageManagerTest {
@@ -54,10 +54,10 @@ public class StorageManagerTest {
          * {@link JsonInsurancePalStorage} class.
          * More extensive testing of UserPref saving/reading is done in {@link JsonInsurancePalStorageTest} class.
          */
-        InsurancePal original = getTypicalAddressBook();
+        ClientBook original = getTypicalAddressBook();
         storageManager.saveInsurancePal(original);
-        ReadOnlyInsurancePal retrieved = storageManager.readInsurancePal().get();
-        assertEquals(original, new InsurancePal(retrieved));
+        ReadOnlyClientBook retrieved = storageManager.readClientBook().get();
+        assertEquals(original, new ClientBook(retrieved));
     }
 
     @Test

--- a/src/test/java/seedu/insurancepal/testutil/AddressBookBuilder.java
+++ b/src/test/java/seedu/insurancepal/testutil/AddressBookBuilder.java
@@ -1,6 +1,6 @@
 package seedu.insurancepal.testutil;
 
-import seedu.insurancepal.model.InsurancePal;
+import seedu.insurancepal.model.ClientBook;
 import seedu.insurancepal.model.person.Person;
 
 /**
@@ -10,13 +10,13 @@ import seedu.insurancepal.model.person.Person;
  */
 public class AddressBookBuilder {
 
-    private InsurancePal addressBook;
+    private ClientBook addressBook;
 
     public AddressBookBuilder() {
-        addressBook = new InsurancePal();
+        addressBook = new ClientBook();
     }
 
-    public AddressBookBuilder(InsurancePal addressBook) {
+    public AddressBookBuilder(ClientBook addressBook) {
         this.addressBook = addressBook;
     }
 
@@ -28,7 +28,7 @@ public class AddressBookBuilder {
         return this;
     }
 
-    public InsurancePal build() {
+    public ClientBook build() {
         return addressBook;
     }
 }

--- a/src/test/java/seedu/insurancepal/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/insurancepal/testutil/TypicalPersons.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import seedu.insurancepal.model.InsurancePal;
+import seedu.insurancepal.model.ClientBook;
 import seedu.insurancepal.model.person.Insurance;
 import seedu.insurancepal.model.person.InsuranceType;
 import seedu.insurancepal.model.person.Person;
@@ -79,8 +79,8 @@ public class TypicalPersons {
     /**
      * Returns an {@code InsurancePal} with all the typical persons.
      */
-    public static InsurancePal getTypicalAddressBook() {
-        InsurancePal ab = new InsurancePal();
+    public static ClientBook getTypicalAddressBook() {
+        ClientBook ab = new ClientBook();
         for (Person person : getTypicalPersons()) {
             ab.addPerson(person);
         }


### PR DESCRIPTION
Currently, InsurancePal is the name of the renamed AddressBook.

This doesn't make much sense, since AddressBook sounds like a storage, while InsurancePal sounds like an app name.

Let's rename it to ClientBook instead.

I've also caught some lingering references to AddressBook. 